### PR TITLE
Use proper SPDX license ID in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "git://github.com/slamdata/purescript-ace-halogen.git"
   },
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "ignore": [
     "**/.*",
     "node_modules",


### PR DESCRIPTION
As of PureScript 0.8.5, we started requiring SPDX license identifiers in the license field of bower.json, which broke `psc-publish` for this package. Sorry about that. This ought to fix it.
